### PR TITLE
Custom BattleState Copier

### DIFF
--- a/rs/calculator/play_path.py
+++ b/rs/calculator/play_path.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from rs.calculator.battle_state import BattleState, Play
-from rs.calculator.helper import pickle_deepcopy
+from rs.calculator.game_state_converter import battlestate_deepcopy
 
 
 class PlayPath:
@@ -32,7 +32,7 @@ def get_paths(path: PlayPath, paths: dict[str, PlayPath]):
         plays = path.state.get_plays()
 
     for play in plays:
-        new_state: BattleState = pickle_deepcopy(path.state)
+        new_state: BattleState = battlestate_deepcopy(path.state)
         new_state.transform_from_play(play, is_first_play=not path.plays)
         new_plays: List[Play] = path.plays.copy()
         new_plays.append(play)
@@ -42,7 +42,7 @@ def get_paths(path: PlayPath, paths: dict[str, PlayPath]):
 
 def get_paths_bfs(state: BattleState, max_path_count: int):
     explored_paths: dict[str, PlayPath] = {}
-    unexplored_paths = [PlayPath([], pickle_deepcopy(state))]
+    unexplored_paths = [PlayPath([], battlestate_deepcopy(state))]
 
     while len(explored_paths) < max_path_count:
         # as long as there are unexplored paths, keep progressing
@@ -64,7 +64,7 @@ def get_paths_bfs(state: BattleState, max_path_count: int):
             plays = path.state.get_plays()
 
         for play in plays:
-            new_state: BattleState = pickle_deepcopy(path.state)
+            new_state: BattleState = battlestate_deepcopy(path.state)
             new_state.transform_from_play(play, is_first_play=not path.plays)
             new_plays: List[Play] = path.plays.copy()
             new_plays.append(play)

--- a/tests/game_state_converter/test_calculator_game_state_converter.py
+++ b/tests/game_state_converter/test_calculator_game_state_converter.py
@@ -1,13 +1,15 @@
 import unittest
+import pickle
 
 from rs.calculator.enums.card_id import CardId
 from rs.calculator.enums.potion_id import PotionId
 from rs.calculator.enums.power_id import PowerId
 from rs.calculator.enums.relic_id import RelicId
-from rs.calculator.game_state_converter import create_battle_state
+from rs.calculator.game_state_converter import create_battle_state, battlestate_deepcopy
 from rs.calculator.interfaces.memory_items import MemoryItem
 from rs.machine.orb import Orb
 from test_helpers.resources import load_resource_state
+
 
 
 class GameStateConverterTest(unittest.TestCase):
@@ -118,3 +120,10 @@ class GameStateConverterTest(unittest.TestCase):
         state = load_resource_state("battles/with_orbs/defect_very_without_orbs.json")
         orbs = state.get_player_orbs()
         self.assertEqual(0, len(orbs))
+
+    def test_battle_state_copy(self):
+        state = load_resource_state('battles/general/complex_case.json')
+        original_battle_state = create_battle_state(state)
+        self.assertEqual(pickle.dumps(original_battle_state, -1),
+                         pickle.dumps(battlestate_deepcopy(original_battle_state), -1))
+


### PR DESCRIPTION
Wrote a method to perform the full deep-copy of the BattleState, instead of utilizing the standard pickle deepcopy.

Testing: I performed multiple runs of the full test suite (including test_complex_case_does_not_timeout) comparing pickle vs the custom. Also ran that test case by itself with both methods. Ended up setting up pycharm to run single test cases.

Single test case: 7.7 seconds approx vs 3.7 seconds.
All test casess: 8.3 vs 4.2 seconds